### PR TITLE
Fix three critical bugs in API

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -36,6 +36,7 @@ logger = logging.getLogger(__name__)
 # Global variables for Ray actors
 deepface_workers: List[ray.actor.ActorHandle] = []
 _current_worker_idx: int = 0
+_worker_idx_lock = __import__('threading').Lock()  # Lock for thread-safe worker selection
 try:
     num_workers = int(os.getenv("NUM_WORKERS", "1"))
 except Exception:
@@ -191,12 +192,19 @@ def get_worker() -> tuple[str, Any]:
     """
     global _current_worker_idx
     provider = WORKER_PROVIDER
+
+    def _get_ray_worker():
+        """Thread-safe round-robin worker selection."""
+        global _current_worker_idx
+        with _worker_idx_lock:
+            worker = deepface_workers[_current_worker_idx % len(deepface_workers)]
+            _current_worker_idx = (_current_worker_idx + 1) % max(1, len(deepface_workers))
+        return worker
+
     # Explicit provider selection
     if provider == "ray":
         if ray.is_initialized() and deepface_workers:
-            worker = deepface_workers[_current_worker_idx % len(deepface_workers)]
-            _current_worker_idx = (_current_worker_idx + 1) % max(1, len(deepface_workers))
-            return "ray", worker
+            return "ray", _get_ray_worker()
         if WORKER_FALLBACK:
             return ("celery", CeleryWorker())
         raise HTTPException(status_code=503, detail="Ray provider selected but unavailable")
@@ -221,9 +229,7 @@ def get_worker() -> tuple[str, Any]:
         return ("local", LocalWorker())
     # Auto mode
     if ray.is_initialized() and deepface_workers:
-        worker = deepface_workers[_current_worker_idx % len(deepface_workers)]
-        _current_worker_idx = (_current_worker_idx + 1) % max(1, len(deepface_workers))
-        return "ray", worker
+        return "ray", _get_ray_worker()
     return ("celery", CeleryWorker())
 
 @app.get("/")
@@ -791,24 +797,71 @@ async def batch_analyze_faces(
     try:
         if len(images) > MAX_BATCH_IMAGES:
             raise HTTPException(status_code=422, detail=f"Too many images in batch. Max: {MAX_BATCH_IMAGES}")
-        # Process all images
-        tasks = []
+
+        # Process all images first
+        processed_images: List[bytes] = []
         for img in images:
             img_bytes = await process_uploaded_file(img)
-            worker = get_worker()
-            task = worker.analyze_face.remote(
-                img_bytes=img_bytes,
-                actions=request.actions,
-                model_name=request.model_name,
-                detector_backend=request.detector_backend,
-                enforce_detection=request.enforce_detection,
-                align=request.align,
-                silent=request.silent
-            )
-            tasks.append(task)
+            processed_images.append(img_bytes)
 
         def _call():
-            return ray.get(tasks)
+            provider, worker = get_worker()
+            actions_list = [a.value for a in request.actions]
+
+            if provider == "ray":
+                # Use Ray for parallel processing
+                tasks = []
+                for img_bytes in processed_images:
+                    task = worker.analyze_face.remote(
+                        img_bytes=img_bytes,
+                        actions=actions_list,
+                        model_name=str(request.model_name.value),
+                        detector_backend=str(request.detector_backend.value),
+                        enforce_detection=request.enforce_detection,
+                        align=request.align,
+                        silent=request.silent
+                    )
+                    tasks.append(task)
+                return ray.get(tasks)
+            else:
+                # For non-Ray providers, process sequentially
+                results = []
+                for img_bytes in processed_images:
+                    if provider == "celery":
+                        from .tasks import celery_app
+                        if celery_app.conf.task_always_eager:
+                            result = LocalWorker().analyze_face(
+                                img_bytes=img_bytes,
+                                actions=actions_list,
+                                model_name=str(request.model_name.value),
+                                detector_backend=str(request.detector_backend.value),
+                                enforce_detection=request.enforce_detection,
+                                align=request.align,
+                                silent=request.silent
+                            )
+                        else:
+                            result = worker.analyze_face(
+                                img_bytes=img_bytes,
+                                actions=actions_list,
+                                model_name=str(request.model_name.value),
+                                detector_backend=str(request.detector_backend.value),
+                                enforce_detection=request.enforce_detection,
+                                align=request.align,
+                                silent=request.silent
+                            )
+                    else:
+                        # local or kafka fallback to local for batch
+                        result = LocalWorker().analyze_face(
+                            img_bytes=img_bytes,
+                            actions=actions_list,
+                            model_name=str(request.model_name.value),
+                            detector_backend=str(request.detector_backend.value),
+                            enforce_detection=request.enforce_detection,
+                            align=request.align,
+                            silent=request.silent
+                        )
+                    results.append(result)
+                return results
 
         results = retry_call(lambda: cb_analyze.call(_call), attempts=2)
 
@@ -828,7 +881,7 @@ async def batch_analyze_faces(
         raise HTTPException(status_code=422, detail=str(e))
     except Exception as e:
         logger.error(f"Error in batch analysis: {e}")
-        raise HTTPException(status_code=500, detail=f"Batch analysis failed: {str(e)}")
+        raise HTTPException(status_code=500, detail="Batch analysis failed")
 
 @app.post("/secure/verify", response_model=VerifyResponse)
 async def secure_verify(payload: SecureVerifyRequest, current_user: User = Depends(require_jwt_or_api_key([Role.OPERATOR, Role.ADMIN]))):

--- a/app/tasks.py
+++ b/app/tasks.py
@@ -26,16 +26,58 @@ celery_app = Celery("deepface", broker=CELERY_BROKER_URL, backend=CELERY_RESULT_
 celery_app.conf.task_always_eager = os.getenv("CELERY_EAGER", "true").lower() == "true"
 celery_app.conf.task_ignore_result = False
 
-# Simple in-memory task registry
+# Simple in-memory task registry with TTL and size limits
 _TASKS: Dict[str, Dict[str, Any]] = {}
 _TASKS_LOCK = RLock()
+
+# Task registry configuration
+_TASK_TTL_SECONDS = int(os.getenv("TASK_TTL_SECONDS", "3600"))  # 1 hour default
+_TASK_MAX_ENTRIES = int(os.getenv("TASK_MAX_ENTRIES", "10000"))  # Max 10k tasks
+_TASK_CLEANUP_INTERVAL = 300  # Cleanup every 5 minutes
+_LAST_CLEANUP_TS: float = 0.0
 
 
 def _now_ts() -> float:
 	return time.time()
 
 
+def _cleanup_expired_tasks() -> None:
+	"""Remove expired tasks and enforce max size limit."""
+	global _LAST_CLEANUP_TS
+	now = _now_ts()
+
+	# Only run cleanup periodically to avoid overhead
+	if now - _LAST_CLEANUP_TS < _TASK_CLEANUP_INTERVAL:
+		return
+
+	with _TASKS_LOCK:
+		_LAST_CLEANUP_TS = now
+
+		# Remove expired tasks
+		expired_keys = [
+			task_id for task_id, entry in _TASKS.items()
+			if now - entry.get("created_at", 0) > _TASK_TTL_SECONDS
+		]
+		for key in expired_keys:
+			del _TASKS[key]
+
+		if expired_keys:
+			logger.debug(f"Cleaned up {len(expired_keys)} expired tasks")
+
+		# If still over limit, remove oldest tasks
+		if len(_TASKS) > _TASK_MAX_ENTRIES:
+			sorted_tasks = sorted(
+				_TASKS.items(),
+				key=lambda x: x[1].get("created_at", 0)
+			)
+			to_remove = len(_TASKS) - _TASK_MAX_ENTRIES
+			for task_id, _ in sorted_tasks[:to_remove]:
+				del _TASKS[task_id]
+			logger.debug(f"Evicted {to_remove} oldest tasks due to size limit")
+
+
 def register_ray_ref(kind: str, ref: "ray.ObjectRef") -> str:
+	_cleanup_expired_tasks()  # Periodic cleanup
 	task_id = f"ray-{uuid.uuid4()}"
 	with _TASKS_LOCK:
 		_TASKS[task_id] = {
@@ -50,6 +92,7 @@ def register_ray_ref(kind: str, ref: "ray.ObjectRef") -> str:
 
 
 def register_celery_task(kind: str, celery_task_id: str) -> str:
+	_cleanup_expired_tasks()  # Periodic cleanup
 	task_id = f"celery-{celery_task_id}"
 	with _TASKS_LOCK:
 		_TASKS[task_id] = {
@@ -64,6 +107,7 @@ def register_celery_task(kind: str, celery_task_id: str) -> str:
 
 
 def register_local_result(kind: str, result: Any) -> str:
+	_cleanup_expired_tasks()  # Periodic cleanup
 	task_id = f"local-{uuid.uuid4()}"
 	with _TASKS_LOCK:
 		_TASKS[task_id] = {
@@ -136,6 +180,7 @@ def _get_kafka_consumer():
 
 
 def register_kafka_task(kind: str, task_id: str) -> str:
+	_cleanup_expired_tasks()  # Periodic cleanup
 	with _TASKS_LOCK:
 		_TASKS[task_id] = {
 			"kind": kind,


### PR DESCRIPTION
1. batch_analyze endpoint was completely broken:
   - get_worker() returns tuple (provider, worker) but code used it directly
   - Fixed to properly unpack tuple and handle all worker providers
   - Fixed enum values not being extracted from request.actions
   - Fixed always using ray.get() regardless of provider

2. Memory leak in task registry:
   - _TASKS dict grew unbounded, never cleaned up
   - Added TTL-based expiration (default 1 hour)
   - Added max entries limit (default 10k tasks)
   - Added periodic cleanup on task registration

3. Race condition in worker selection:
   - _current_worker_idx was modified without locking
   - Added threading.Lock for thread-safe round-robin selection